### PR TITLE
Move Saturn vernier and ullage thrusters to a different group than main engines

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_saturn/sat1bmesh.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/sat1bmesh.cpp
@@ -623,7 +623,7 @@ void Saturn1b::SetSecondStageEngines (double offset)
 		AddExhaust(th_ver[i], 7.0, 0.2, exhaust_tex);
 		AddExhaustStream(th_ver[i], &solid_exhaust);
 	}
-	thg_ver = CreateThrusterGroup (th_ver, 3,THGROUP_USER);
+	thg_ver = CreateThrusterGroup (th_ver, 3, (THGROUP_TYPE)(THGROUP_USER + 1));
 }
 
 void Saturn1b::SeparateStage (int new_stage)

--- a/Orbitersdk/samples/ProjectApollo/src_saturn/sat5mesh.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/sat5mesh.cpp
@@ -803,7 +803,7 @@ void SaturnV::SetSecondStageEngines(double offset)
 			AddExhaustStream (th_ull[i], &solid_exhaust);
 		}
 
-		thg_ull = CreateThrusterGroup (th_ull, SII_UllageNum, THGROUP_USER);
+		thg_ull = CreateThrusterGroup (th_ull, SII_UllageNum, (THGROUP_TYPE)(THGROUP_USER + 1));
 	}
 
 	sii->RecalculateEngineParameters(THRUST_SECOND_VAC);
@@ -1046,7 +1046,7 @@ void SaturnV::SetThirdStageEngines (double offset)
 	for (int i = 0; i < 2; i++)
 		AddExhaust (th_ver[i], 5.0, 0.25, exhaust_tex);
 
-	thg_ver = CreateThrusterGroup (th_ver, 2, THGROUP_USER);
+	thg_ver = CreateThrusterGroup (th_ver, 2, (THGROUP_TYPE)(THGROUP_USER + 1));
 
 	sivb->RecalculateEngineParameters(THRUST_THIRD_VAC);
 


### PR DESCRIPTION
This fixes the engine sound being cut off during boost after staging, due to the two thruster groups conflicting with each other and overriding XRSound's understanding of what the engine thrust level is.

I have tested this branch with XRSound 2 on Orbiter Beta and it builds fine and works fine through a full simulated boost. We will probably want to make a custom XRSound config file to disable things like the random cabin ambiance and ATC callouts etc. before we merge this, but otherwise I see no blocking issues.